### PR TITLE
Improvements to Chunk Processor API

### DIFF
--- a/include/png-chunk-processor.h
+++ b/include/png-chunk-processor.h
@@ -2,23 +2,74 @@
 #define STEG_PNG_PNG_CHUNK_PROCESSOR_H
 
 #include <stdlib.h>
+#include <sys/types.h>
 
-#include "strbuf.h"
+/**
+ * png-chunk-processor usage:
+ *
+ * The png-chunk-processor API can be used to process a PNG image, allowing the
+ * caller to iterate over all the chunks in a PNG file and incrementally
+ * stream the individual file chunk data portions.
+ *
+ * Example Usage:
+ * void example() {
+ * 		int fd = open(file_path, O_RDONLY);
+ * 		struct chunk_iterator_ctx ctx;
+ * 		if (chunk_iterator_init_ctx(&ctx, fd) != 0)
+ * 			DIE("could not initialize chunk iterator context");
+ *
+ * 		do {
+ * 			int has_next = chunk_iterator_has_next(&ctx);
+ * 			if (has_next < 0)
+ * 				DIE("corrupted file or context");
+ * 			if (!has_next)
+ * 				break;
+ *
+ * 			if (chunk_iterator_next(&ctx) != 0)
+ * 				DIE("corrupted file or context");
+ *
+ * 			unsigned char data[1024];
+ * 			while (1) {
+ * 				ssize_t bytes_read = chunk_iterator_read_data(&ctx, data, 1024);
+ *				if (bytes_read < 0)
+ *					break;
+ *
+ *				// process data
+ * 			}
+ * 		} while (1);
+ *
+ * 		chunk_iterator_destroy_ctx(&ctx);
+ * 		close(fd);
+ * }
+ *
+ * */
 
 #define SIGNATURE_LENGTH 8
 #define CHUNK_TYPE_LENGTH 4
 
 extern unsigned char PNG_SIG[];
-extern char IEND_CHUNK_TYPE[];
+
+extern const char IHDR_CHUNK_TYPE[];
+extern const char PLTE_CHUNK_TYPE[];
+extern const char IDAT_CHUNK_TYPE[];
+extern const char IEND_CHUNK_TYPE[];
+
+struct png_chunk_detail {
+	char chunk_type[CHUNK_TYPE_LENGTH];
+	u_int32_t data_length;
+	u_int32_t chunk_crc;
+};
 
 struct chunk_iterator_ctx {
 	int fd;
-	size_t pos;
+	unsigned int initialized: 1;
+	off_t chunk_file_offset;
+	struct png_chunk_detail current_chunk;
 };
 
 /**
  * Initialize a chunk_iterator_ctx. The file descriptor must be a valid open
- * file descriptor.
+ * file descriptor, and cannot be a socket, pipe or FIFO.
  *
  * Reads the the first eight bytes from the file and verifies that the file
  * is a valid PNG file.
@@ -29,39 +80,77 @@ struct chunk_iterator_ctx {
 int chunk_iterator_init_ctx(struct chunk_iterator_ctx *ctx, int fd);
 
 /**
- * Read the next chunk into the given buffer.
+ * Determine whether there are any file chunks left to be processed by this chunk
+ * iterator, without advancing the iterator.
  *
- * Returns 1 if result has been updated with the contents of the next chunk, or
- * zero if no more chunks exist. Returns -1 if a chunk could not be read successfully,
- * or is corrupt.
+ * Returns 0 if there are no more chunks to be processed, and 1 if more chunks
+ * remain. If an unexpected error occurs, -1 is returned and this chunk iterator
+ * is no longer reliable.
  * */
-int chunk_iterator_next_chunk(struct chunk_iterator_ctx *ctx, struct strbuf *result);
+int chunk_iterator_has_next(struct chunk_iterator_ctx *ctx);
+
+/**
+ * Advance the chunk iterator to the next chunk. Once invoked, the internal
+ * context state is updated with the details of the new chunk.
+ *
+ * Note that the caller is responsible for ensuring that the chunk is not
+ * corrupted (valid CRC).
+ *
+ * Returns 0 if the internal state was updated successfully. Returns -1 if the
+ * state could not be updated for any reason (possibly corrupted file).
+ * */
+int chunk_iterator_next(struct chunk_iterator_ctx *ctx);
+
+/**
+ * Read at most 'length' bytes from the current chunk data into the buffer. If
+ * all bytes have been read for the current chunk, returns zero and the buffer
+ * is left unchanged. Otherwise returns the number of bytes read into the buffer.
+ * */
+ssize_t chunk_iterator_read_data(struct chunk_iterator_ctx *ctx, unsigned char* buffer, size_t length);
+
+/**
+ * Get the length of the current chunk. The length is written to 'len'.
+ *
+ * Returns zero if successful, and non-zero otherwise.
+ * */
+int chunk_iterator_get_chunk_data_length(struct chunk_iterator_ctx *ctx, u_int32_t *len);
+
+/**
+ * Get the type of the current chunk. The given `type` must have a length of
+ * CHUNK_TYPE_LENGTH.
+ *
+ * Returns zero if successful, and non-zero otherwise.
+ * */
+int chunk_iterator_get_chunk_type(struct chunk_iterator_ctx *ctx, char type[]);
+
+/**
+ * Get the CRC for the current chunk.
+ *
+ * Returns zero if successful, and non-zero otherwise.
+ * */
+int chunk_iterator_get_chunk_crc(struct chunk_iterator_ctx *ctx, u_int32_t *crc);
+
+/**
+ * Return 1 if the current chunk is a 'critical' chunk, and zero if the chunk
+ * is ancillary.
+ *
+ * Returns -1 if chunk_iterator_next() has not yet been called, or the iterator has
+ * reached the end of the file.
+ * */
+int chunk_iterator_is_critical(struct chunk_iterator_ctx *ctx);
+
+/**
+ * Return 1 if the current chunk is a 'ancillary' chunk, and zero if the chunk
+ * is critical.
+ *
+ * Returns -1 if chunk_iterator_next() has not yet been called, or the iterator has
+ * reached the end of the file.
+ * */
+int chunk_iterator_is_ancillary(struct chunk_iterator_ctx *ctx);
 
 /**
  * Destroy a chunk_iterator_ctx.
  * */
 void chunk_iterator_destroy_ctx(struct chunk_iterator_ctx *ctx);
-
-/**
- * Parse a PNG file chunk for the data length field.
- *
- * Returns zero if the length was parsed successfully, and 1 otherwise.
- * */
-int png_parse_chunk_data_length(const struct strbuf *chunk, u_int32_t *len);
-
-/**
- * Parse a PNG file chunk for the chunk type field. The given `type` must have
- * a length of CHUNK_TYPE_LENGTH.
- *
- * Returns zero of the type was parsed successfully, and 1 otherwise.
- * */
-int png_parse_chunk_type(const struct strbuf *chunk, char type[]);
-
-/**
- * Parse a PNG file chunk for the CRC field.
- *
- * Returns zero if the CRC was parsed successfully, and 1 otherwise.
- * */
-int png_parse_chunk_crc(const struct strbuf *chunk, u_int32_t *crc);
 
 #endif //STEG_PNG_PNG_CHUNK_PROCESSOR_H

--- a/src/main.c
+++ b/src/main.c
@@ -24,9 +24,9 @@ int main(int argc, char *argv[])
 
 	const struct command_option main_cmd_options[] = {
 			OPT_GROUP("subcommands"),
-			OPT_CMD("embed", "embed a message in a PNG image"),
-			OPT_CMD("extract", "extract a message in a PNG image"),
-			OPT_CMD("inspect", "inspect the contents of a PNG image"),
+			OPT_CMD("embed", "embed a message in a PNG image", NULL),
+			OPT_CMD("extract", "extract a message in a PNG image", NULL),
+			OPT_CMD("inspect", "inspect the contents of a PNG image", NULL),
 			OPT_GROUP("options"),
 			OPT_BOOL('h', "help", "show help and exit", &help),
 			OPT_END()

--- a/src/md5.c
+++ b/src/md5.c
@@ -50,7 +50,22 @@
 # define md5_buffer __md5_buffer
 #endif
 
+#if HAVE_BYTESWAP_H
 #include <byteswap.h>
+#else
+#define bswap_16(value) \
+((((value) & 0xff) << 8) | ((value) >> 8))
+
+#define bswap_32(value) \
+(((uint32_t)bswap_16((uint16_t)((value) & 0xffff)) << 16) | \
+(uint32_t)bswap_16((uint16_t)((value) >> 16)))
+
+#define bswap_64(value) \
+(((uint64_t)bswap_32((uint32_t)((value) & 0xffffffff)) \
+<< 32) | \
+(uint64_t)bswap_32((uint32_t)((value) >> 32)))
+#endif
+
 #ifdef WORDS_BIGENDIAN
 # define SWAP(n) bswap_32 (n)
 #else

--- a/src/png-chunk-processor.c
+++ b/src/png-chunk-processor.c
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <ctype.h>
+#include <unistd.h>
 #include <arpa/inet.h>
 
 #include "png-chunk-processor.h"
@@ -11,10 +12,19 @@ unsigned char PNG_SIG[] = {
 		0x0d, 0x0a, 0x1a, 0x0a
 };
 
-char IEND_CHUNK_TYPE[] = {'I', 'E', 'N', 'D'};
+const char IHDR_CHUNK_TYPE[] = {'I', 'H', 'D', 'R'};
+const char PLTE_CHUNK_TYPE[] = {'P', 'L', 'T', 'E'};
+const char IDAT_CHUNK_TYPE[] = {'I', 'D', 'A', 'T'};
+const char IEND_CHUNK_TYPE[] = {'I', 'E', 'N', 'D'};
+
+static int construct_png_chunk_detail(int, struct png_chunk_detail *);
 
 int chunk_iterator_init_ctx(struct chunk_iterator_ctx *ctx, int fd)
 {
+	off_t offset = lseek(fd, 0, SEEK_SET);
+	if (offset < 0)
+		return -1;
+
 	unsigned char signature[SIGNATURE_LENGTH];
 	if (recoverable_read(fd, signature, SIGNATURE_LENGTH) != SIGNATURE_LENGTH)
 		return -1;
@@ -23,82 +33,227 @@ int chunk_iterator_init_ctx(struct chunk_iterator_ctx *ctx, int fd)
 		return 1;
 
 	ctx->fd = fd;
-	ctx->pos = SIGNATURE_LENGTH;
+	ctx->initialized = 0;
+	ctx->current_chunk = (struct png_chunk_detail) {
+		.chunk_type = {0, 0, 0, 0},
+		.data_length = 0,
+		.chunk_crc = 0
+	};
+
 	return 0;
 }
 
-int chunk_iterator_next_chunk(struct chunk_iterator_ctx *ctx, struct strbuf *result)
+int chunk_iterator_has_next(struct chunk_iterator_ctx *ctx)
 {
-	// read the chunk length
-	u_int32_t len = 0;
-	if (recoverable_read(ctx->fd, &len, sizeof(u_int32_t)) != sizeof(u_int32_t))
+	// get the current file offset
+	off_t file_offset = lseek(ctx->fd, 0, SEEK_CUR);
+	if (file_offset < 0)
+		return -1;
+	if (file_offset < SIGNATURE_LENGTH)
+		return -1;
+
+	// move the file offset to the beginning of the next chunk
+	struct png_chunk_detail current_chunk = ctx->current_chunk;
+	if (ctx->initialized) {
+		off_t next_chunk_offset = ctx->chunk_file_offset;
+		next_chunk_offset += sizeof(u_int32_t);
+		next_chunk_offset += sizeof(char) * CHUNK_TYPE_LENGTH;
+		next_chunk_offset += sizeof(unsigned char) * current_chunk.data_length;
+		next_chunk_offset += sizeof(u_int32_t);
+
+		if (lseek(ctx->fd, next_chunk_offset, SEEK_SET) < 0)
+			return -1;
+	}
+
+	// try to construct the png_chunk_detail, but simply throw away the result
+	struct png_chunk_detail detail;
+	int ret = construct_png_chunk_detail(ctx->fd, &detail);
+	if (ret == -1)
+		return -1;
+	if (ret == 1)
 		return 0;
-	ctx->pos += sizeof(u_int32_t);
 
-	strbuf_attach_bytes(result, &len, sizeof(u_int32_t));
-
-	len = CHUNK_TYPE_LENGTH + ntohl(len) + sizeof(u_int32_t);
-	strbuf_grow(result, result->len + len);
-
-	// read the chunk full chunk
-	if (recoverable_read(ctx->fd, result->buff + result->len, len) != len)
-		return -1;
-	ctx->pos += len;
-	result->len += len;
-
-	// verify crc
-	u_int32_t crc = 0;
-	if (png_parse_chunk_crc(result, &crc))
-		return -1;
-
-	u_int32_t computed_crc = crc32(result->buff + sizeof(u_int32_t), result->len - sizeof(u_int32_t) - sizeof(u_int32_t));
-	if (crc != computed_crc)
+	// reset fd offset to where it was initially
+	if (lseek(ctx->fd, file_offset, SEEK_SET) < 0)
 		return -1;
 
 	return 1;
 }
 
+int chunk_iterator_next(struct chunk_iterator_ctx *ctx)
+{
+	// move the file offset to the beginning of the next chunk
+	struct png_chunk_detail current_chunk = ctx->current_chunk;
+	if (ctx->initialized) {
+		off_t next_chunk_offset = ctx->chunk_file_offset;
+		next_chunk_offset += sizeof(u_int32_t);
+		next_chunk_offset += sizeof(char) * CHUNK_TYPE_LENGTH;
+		next_chunk_offset += sizeof(unsigned char) * current_chunk.data_length;
+		next_chunk_offset += sizeof(u_int32_t);
+
+		off_t offset = lseek(ctx->fd, next_chunk_offset, SEEK_SET);
+		if (offset < 0)
+			return -1;
+	}
+
+	// read the current file offset from the file descriptor
+	off_t file_offset = lseek(ctx->fd, 0, SEEK_CUR);
+	if (file_offset < 0)
+		return -1;
+	if (file_offset < SIGNATURE_LENGTH)
+		return -1;
+
+	// try to construct the png_chunk_detail
+	ctx->initialized = 1;
+	ctx->chunk_file_offset = lseek(ctx->fd, 0, SEEK_CUR);
+	if (ctx->chunk_file_offset < 0)
+		return -1;
+
+	int ret = construct_png_chunk_detail(ctx->fd, &ctx->current_chunk);
+	if (ret != 0)
+		return ret;
+
+	// seek fd file offset to beginning of data portion
+	off_t data_offset = file_offset + sizeof(u_int32_t) + (sizeof(char) * CHUNK_TYPE_LENGTH);
+	if (lseek(ctx->fd, data_offset, SEEK_SET) < 0)
+		return -1;
+
+	return 0;
+}
+
+ssize_t chunk_iterator_read_data(struct chunk_iterator_ctx *ctx, unsigned char* buffer, size_t length)
+{
+	if (!ctx->initialized)
+		return -1;
+
+	off_t file_offset = lseek(ctx->fd, 0, SEEK_CUR);
+	if (file_offset < 0)
+		return -1;
+	if (file_offset < SIGNATURE_LENGTH)
+		return -1;
+
+	off_t data_segment_start = ctx->chunk_file_offset
+			+ sizeof(u_int32_t) + (sizeof(char) * CHUNK_TYPE_LENGTH);
+	if (file_offset < data_segment_start)
+		return -1;
+	if (file_offset >= (data_segment_start + ctx->current_chunk.data_length))
+		return 0;
+
+	size_t bytes_left_to_read = data_segment_start + ctx->current_chunk.data_length
+			- file_offset;
+	bytes_left_to_read = bytes_left_to_read > length ? length : bytes_left_to_read;
+	if (recoverable_read(ctx->fd, buffer, bytes_left_to_read) != bytes_left_to_read)
+		return -1;
+
+	return bytes_left_to_read;
+}
+
+int chunk_iterator_get_chunk_data_length(struct chunk_iterator_ctx *ctx, u_int32_t *len)
+{
+	if (!ctx->initialized)
+		return 1;
+
+	*len = ctx->current_chunk.data_length;
+	return 0;
+}
+
+int chunk_iterator_get_chunk_type(struct chunk_iterator_ctx *ctx, char type[])
+{
+	if (!ctx->initialized)
+		return 1;
+
+	memcpy(type, ctx->current_chunk.chunk_type, CHUNK_TYPE_LENGTH);
+	return 0;
+}
+
+int chunk_iterator_get_chunk_crc(struct chunk_iterator_ctx *ctx, u_int32_t *crc)
+{
+	if (!ctx->initialized)
+		return 1;
+
+	*crc = ctx->current_chunk.chunk_crc;
+	return 0;
+}
+
+int chunk_iterator_is_critical(struct chunk_iterator_ctx *ctx)
+{
+	if (!ctx->initialized)
+		return -1;
+
+	if (!memcmp(IHDR_CHUNK_TYPE, ctx->current_chunk.chunk_type, CHUNK_TYPE_LENGTH))
+		return 1;
+	if (!memcmp(PLTE_CHUNK_TYPE, ctx->current_chunk.chunk_type, CHUNK_TYPE_LENGTH))
+		return 1;
+	if (!memcmp(IDAT_CHUNK_TYPE, ctx->current_chunk.chunk_type, CHUNK_TYPE_LENGTH))
+		return 1;
+	if (!memcmp(IEND_CHUNK_TYPE, ctx->current_chunk.chunk_type, CHUNK_TYPE_LENGTH))
+		return 1;
+
+	return 0;
+}
+
+int chunk_iterator_is_ancillary(struct chunk_iterator_ctx *ctx)
+{
+	if (!ctx->initialized)
+		return -1;
+
+	return !chunk_iterator_is_critical(ctx);
+}
+
 void chunk_iterator_destroy_ctx(struct chunk_iterator_ctx *ctx)
 {
 	ctx->fd = -1;
-	ctx->pos = 0;
+	ctx->current_chunk = (struct png_chunk_detail) {
+			.chunk_type = {0, 0, 0, 0},
+			.data_length = 0,
+			.chunk_crc = 0
+	};
 }
 
-int png_parse_chunk_data_length(const struct strbuf *chunk, u_int32_t *len)
+/**
+ * Attempt to construct a struct png_chunk_detail from a given position in a file.
+ *
+ * The given file descriptor fd must be open and seekable, and must be positioned
+ * at the first byte of the png file chunk. The file offset is mutated after a
+ * call to this function, so the caller must reposition the file offset with
+ * lseek(), as needed.
+ *
+ * Returns zero if the chunk was processed successfully. Otherwise, if the given
+ * file descriptor does not appear to represent a valid png chunk, returns 1. If
+ * an unexpected error occurs, returns -1.
+ * */
+static int construct_png_chunk_detail(int fd, struct png_chunk_detail *new_chunk)
 {
-	if (chunk->len <= sizeof(u_int32_t))
+	// read and set the chunk's file offset
+	off_t file_offset = lseek(fd, 0, SEEK_CUR);
+	if (file_offset < 0)
+		return -1;
+
+	// read chunk data length and convert from network byte order to host byte order
+	if (recoverable_read(fd, &new_chunk->data_length, sizeof(u_int32_t)) != sizeof(u_int32_t))
 		return 1;
+	new_chunk->data_length = ntohl(new_chunk->data_length);
 
-	u_int32_t tmp = *((u_int32_t *)chunk->buff);
-	*len = ntohl(tmp);
-	return 0;
-}
-
-int png_parse_chunk_type(const struct strbuf *chunk, char type[])
-{
+	// read chunk type and ensure valid asccii characters
+	if (recoverable_read(fd, new_chunk->chunk_type, CHUNK_TYPE_LENGTH) != CHUNK_TYPE_LENGTH)
+		return 1;
 	for (size_t i = 0; i < CHUNK_TYPE_LENGTH; i++) {
-		if (i >= chunk->len)
-			return 1;
-
-		type[i] = chunk->buff[sizeof(u_int32_t) + i];
-		if (!isascii(type[i]))
+		if (!isascii(new_chunk->chunk_type[i]))
 			return 1;
 	}
 
-	return 0;
-}
+	// seek to and read CRC and convert from network byte order to host byte order
+	off_t crc_offset = file_offset;
+	crc_offset += sizeof(u_int32_t);
+	crc_offset += sizeof(char) * CHUNK_TYPE_LENGTH;
+	crc_offset += sizeof(unsigned char) * new_chunk->data_length;
 
-int png_parse_chunk_crc(const struct strbuf *chunk, u_int32_t *crc)
-{
-	u_int32_t data_len = 0;
-	if (png_parse_chunk_data_length(chunk, &data_len))
+	if (lseek(fd, crc_offset, SEEK_SET) < 0)
+		return -1;
+	if (recoverable_read(fd, &new_chunk->chunk_crc, sizeof(u_int32_t)) != sizeof(u_int32_t))
 		return 1;
 
-	size_t crc_field_index = sizeof(u_int32_t) + CHUNK_TYPE_LENGTH + data_len;
-	if (chunk->len != crc_field_index + sizeof(u_int32_t))
-		return 1;
+	new_chunk->chunk_crc = ntohl(new_chunk->chunk_crc);
 
-	u_int32_t tmp = *((u_int32_t *)(chunk->buff + crc_field_index));
-	*crc = ntohl(tmp);
 	return 0;
 }


### PR DESCRIPTION
Prior to these changes, the chunk processor accepted a `strbuf *`, and on each iteration would populate it with the entire chunk. This is not ideal since it has the need to load the entire chunk heap memory, which could (in theory) be infinitely large. This is also potentially less performant, since the buffer needs to be parsed anytime the data length, chunk type or CRC are needed.

The new implementation allows the caller to iterate over each chunk in the file and stream into a fixed size buffer the chunk data.  Furthermore, the data length, chunk type and CRC do not need to be parsed every time it is needed.