### PR TITLE
improvements to embed builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,16 @@ $ steg-png --help
 Using the tool is simple.
 
 ```
-usage: steg-png --embed (-m | --message <message>) [-o | --output <file>] <file>
-   or: steg-png --embed (-f | --file <file>) [-o | --output <file>] <file>
-   or: steg-png --embed (-h | --help)
+usage: steg-png embed (-m | --message <message>) [-o | --output <file>] <file>
+   or: steg-png embed (-f | --file <file>) [-o | --output <file>] <file>
+   or: steg-png embed (-h | --help)
 
     -m, --message <message>
                         specify the message to embed in the png image
     -f, --file <file>   specify a file to embed in the png image
     -o, --output <file>
                         output to a specific file
-    -q, --quiet         suppress output to stdout
+    -q, --quiet         suppress informational summary to stdout
     -h, --help          show help and exit
 ```
 

--- a/include/png-chunk-processor.h
+++ b/include/png-chunk-processor.h
@@ -106,7 +106,7 @@ int chunk_iterator_next(struct chunk_iterator_ctx *ctx);
  * all bytes have been read for the current chunk, returns zero and the buffer
  * is left unchanged. Otherwise returns the number of bytes read into the buffer.
  * */
-ssize_t chunk_iterator_read_data(struct chunk_iterator_ctx *ctx, unsigned char* buffer, size_t length);
+ssize_t chunk_iterator_read_data(struct chunk_iterator_ctx *ctx, unsigned char *buffer, size_t length);
 
 /**
  * Get the length of the current chunk. The length is written to 'len'.

--- a/src/utils.c
+++ b/src/utils.c
@@ -29,7 +29,7 @@ NORETURN void FATAL(const char *fmt, ...)
 	va_list varargs;
 
 	va_start(varargs, fmt);
-	print_message(stderr, "Fatal Error: ", fmt, varargs);
+	print_message(stderr, "fatal: ", fmt, varargs);
 	va_end(varargs);
 
 	exit_routine(EXIT_FAILURE);
@@ -51,7 +51,7 @@ void WARN(const char *fmt, ...)
 	va_list varargs;
 
 	va_start(varargs, fmt);
-	print_message(stderr, "Warn: ", fmt, varargs);
+	print_message(stderr, "warn: ", fmt, varargs);
 	va_end(varargs);
 }
 


### PR DESCRIPTION
Refactored the embed builtin to remove duplicate code. In the process,
adapted the existing implementation to first write to a temporary file,
and then copy to its final location if the embed process succeeds. This
will avoid leaving partially written or corrupted PNG files, which could
mislead the user.