### PR TITLE
inspect: include control bytes in hexdump output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # steg-png
 [![Build Status](https://travis-ci.com/brandon1024/steg-png.svg?branch=master)](https://travis-ci.com/brandon1024/steg-png)
 
-`steg-png` is a simple C-based commandline application that can be used to embed data in Portable Network Graphics (PNG) images. This concept is known as steganography, and is useful for concealing hidden messages in otherwise unassuming files.
+`steg-png` is a simple toolset for embedding data in Portable Network Graphics (PNG) images. This concept is known as steganography, and is useful for concealing hidden messages in otherwise unassuming files.
 
 ![](screenshot1.png)
 
@@ -69,11 +69,14 @@ usage: steg-png extract [-o | --output <file>] <file>
     --hexdump           print a hexdump of the embedded data
     -h, --help          show help and exit
 
-usage: steg-png inspect [(--filter <chunk type>)...] [--critical] [--ancillary] [--hexdump] <file>
-   or: steg-png inspect (-i | --interactive) <file>
+
+usage: steg-png inspect [(--filter <chunk type>)...] [--critical] [--ancillary] <file>
+   or: steg-png inspect [<options>...] --hexdump [--full-source] <file>
+   or: steg-png inspect [<options>...] --machine-readable [(-z | --nul)] <file>
    or: steg-png inspect (-h | --help)
 
-    --hexdump           print a canonical hex+ASCII hexdump of the embedded data
+    --hexdump           print a canonical hex+ASCII hexdump of chunk data as it appears in the file
+    --full-source       show full hexdump of chunk as it appears in the file (including control bytes)
                         show chunks with specific type
     --critical          show critical chunks
     --ancillary         show ancillary chunks
@@ -81,6 +84,7 @@ usage: steg-png inspect [(--filter <chunk type>)...] [--critical] [--ancillary] 
                         show output in machine-readable format
     -z, --nul           terminate lines with NUL byte instead of line feed
     -h, --help          show help and exit
+
 ```
 
 ## Example Usage

--- a/include/png-chunk-processor.h
+++ b/include/png-chunk-processor.h
@@ -63,6 +63,7 @@ struct png_chunk_detail {
 struct chunk_iterator_ctx {
 	int fd;
 	unsigned int initialized: 1;
+	unsigned int read_full: 1;
 	off_t chunk_file_offset;
 	struct png_chunk_detail current_chunk;
 };
@@ -102,9 +103,16 @@ int chunk_iterator_has_next(struct chunk_iterator_ctx *ctx);
 int chunk_iterator_next(struct chunk_iterator_ctx *ctx);
 
 /**
- * Read at most 'length' bytes from the current chunk data into the buffer. If
- * all bytes have been read for the current chunk, returns zero and the buffer
- * is left unchanged. Otherwise returns the number of bytes read into the buffer.
+ * Read data from the current chunk into the given buffer.
+ *
+ * This function has two modes of operation. If `read_full` is enabled on the
+ * context, reads will include header/control bytes and data. If disabled,
+ * only data from the chunks data segment are read.
+ *
+ * At most 'length' bytes are read from the chunk. If all bytes has been read
+ * for the current chunk, returns zero and the buffer is left unchanged.
+ * Otherwise returns the number of bytes read into the buffer. This function
+ * may also return -1 if the context has an inconsistent state.
  * */
 ssize_t chunk_iterator_read_data(struct chunk_iterator_ctx *ctx, unsigned char *buffer, size_t length);
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -111,6 +111,10 @@ ssize_t copy_file_fd(int dest_fd, int src_fd);
  * the offset of the chunk of data; useful for printing the hexdump of a file or
  * larger stream (requiring multiple calls to this function).
  *
+ * Contiguous data can be printed with multiple invocations of this function,
+ * granted the `len` given be a multiple of 16. Otherwise, data won't be printed
+ * in a user-friendly manner.
+ *
  * Example:
  * 00000000  23 20 4a 65 74 42 72 61  69 6e 73 0a 2e 69 64 65  |# JetBrains..ide|
  * 00000010  61 2f 0a 0a 23 20 6d 61  63 4f 53 0a 2e 44 53 5f  |a/..# macOS..DS_|


### PR DESCRIPTION
Fixes #26 

Expose a new option '--full-source' that can be used in combination with
the '--hexdump' option to include chunk header and control bytes (chunk type,
length, data and CRC) in the hexdump output.

Updated project readme to reflect this.